### PR TITLE
Setting default value for bool flags

### DIFF
--- a/dynbool.go
+++ b/dynbool.go
@@ -16,6 +16,7 @@ func DynBool(flagSet *flag.FlagSet, name string, value bool, usage string) *DynB
 	v := boolToInt(value)
 	dynValue := &DynBoolValue{ptr: &v}
 	flag := flagSet.VarPF(dynValue, name, "", usage)
+	flag.NoOptDefVal = "true"
 	MarkFlagDynamic(flag)
 	return dynValue
 }


### PR DESCRIPTION
Setting the default value for DynBool flags so they are parsed correctly as `--flag` rather than requiring an argument (`--flag=true` or `--flag true`).

the pflag library does this for Bools:
```
// BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
	flag.NoOptDefVal = "true"
}
```